### PR TITLE
remove_plexus_utils_version Remove plexus-utils version from depends-…

### DIFF
--- a/depends-maven-plugin/pom.xml
+++ b/depends-maven-plugin/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>org.sonatype.plexus</groupId>


### PR DESCRIPTION
…maven-plugin

This will ensure it is getting the version that is provided with maven 

See https://maven.apache.org/docs/3.6.2/release-notes.html