### PR TITLE
[SM-5531] Remove references to Resolver

### DIFF
--- a/depends-maven-plugin/src/main/java/org/apache/servicemix/tooling/depends/GenerateDependsFileMojo.java
+++ b/depends-maven-plugin/src/main/java/org/apache/servicemix/tooling/depends/GenerateDependsFileMojo.java
@@ -23,12 +23,6 @@ import java.io.PrintStream;
 import java.util.*;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactCollector;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
-import org.apache.maven.artifact.resolver.DefaultArtifactCollector;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -77,25 +71,8 @@ public class GenerateDependsFileMojo extends AbstractMojo {
     @Parameter( defaultValue = "${project.build.directory}/classes/META-INF/maven/dependencies.properties" )
     private File outputFile;
 
-    @Parameter( defaultValue = "${localRepository}" )
-    protected ArtifactRepository localRepo;
-
-    @Parameter( defaultValue = "${project.remoteArtifactRepositories}" )
-    protected List remoteRepos;
-
     @Parameter( defaultValue = "${filterGroupIds}" )
     protected String[] filterGroupIds;
-
-    @Component
-    protected ArtifactMetadataSource artifactMetadataSource;
-
-    @Component
-    protected ArtifactResolver resolver;
-
-    protected ArtifactCollector collector = new DefaultArtifactCollector();
-
-    @Component
-    protected ArtifactFactory factory;
 
     @Component
     private BuildContext buildContext;


### PR DESCRIPTION
maven-3.9.1 warns about localRepo being referenced. It turns out it
is not actually used anywhere, along with a number of other fields.
Remove them to fix the warning.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
